### PR TITLE
added `grunt-cli` to `package.json` to use `grunt` locally

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "devDependencies": {
     "grunt": "^0.4.1",
+    "grunt-cli": "^1.2.0",
     "grunt-contrib-clean": "^0.7.0",
     "grunt-contrib-copy": "^0.8.2",
     "grunt-contrib-jshint": "~0.11.3",

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.2",
   "private": true,
   "scripts": {
-    "start": "grunt build && node app.js",
-    "watch": "grunt build && (grunt watch &) && node app.js"
+    "start": "./node_modules/.bin/grunt build && node app.js",
+    "watch": "./node_modules/.bin/grunt build && (./node_modules/.bin/grunt watch &) && node app.js"
   },
   "dependencies": {
     "autoprefixer": "^6.1.2",


### PR DESCRIPTION
So it's not needed to install grunt system wide.

This is also useful for building docker images. See https://hub.docker.com/r/pklink/microglark/
